### PR TITLE
Add missing option use_ssl: true

### DIFF
--- a/lib/instasent.rb
+++ b/lib/instasent.rb
@@ -127,7 +127,7 @@ module Instasent
       req.add_field("Accept", "application/json")
       req.add_field("Content-Type", "application/json")
 
-      res = Net::HTTP.start(url_parsed.host, url_parsed.port) { |http|
+      res = Net::HTTP.start(url_parsed.host, url_parsed.port, use_ssl: true) { |http|
         http.request(req)
       }
 


### PR DESCRIPTION
Needed to work with HTTPS

Reference:
https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-HTTPS